### PR TITLE
feat(phase-b): onboarding scaffolding (flag, package, route, i18n, targeted tsc, e2e smoke)

### DIFF
--- a/apps/web-next/src/app/[locale]/onboarding/page.tsx
+++ b/apps/web-next/src/app/[locale]/onboarding/page.tsx
@@ -1,0 +1,45 @@
+import { notFound } from "next/navigation";
+import { isOnboardingEnabled } from "@/config/flags";
+import { generatePlan, type Answer, type Plan } from "@schwalbe/onboarding";
+import { useTranslations } from "next-intl";
+
+export default function OnboardingPage({ params }: { params: { locale: string } }) {
+  if (!isOnboardingEnabled()) {
+    notFound();
+  }
+  const t = useTranslations("onboarding");
+  const answers: Answer[] = [
+    { key: "priority", value: "safety" },
+    { key: "timeAvailable", value: "10m" },
+  ];
+  const plan = generatePlan(answers);
+
+  return (
+    <main className="min-h-screen text-slate-100 container mx-auto px-4 pt-28 pb-16">
+      <h1 className="text-3xl font-semibold mb-4">{t("title")}</h1>
+      <p className="text-slate-300 mb-8">{t("subtitle")}</p>
+
+      <section className="rounded-lg border border-slate-700 bg-slate-900/40 p-6 mb-8">
+        <h2 className="text-xl font-semibold mb-2">{t("plan.heading")}</h2>
+        <p className="text-slate-300 mb-4">{t("plan.description")}</p>
+        <ul className="list-disc pl-5 space-y-2">
+          {plan.milestones.map((m: Plan["milestones"][number]) => (
+            <li key={m.id}>
+              <span className="font-medium">{m.title}</span>
+              <span className="text-slate-400"> — {m.description} ({m.estimateMinutes} min)</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="flex gap-3">
+        <button className="inline-flex items-center justify-center rounded-lg bg-slate-700/70 hover:bg-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 text-white px-6 py-3 text-base font-semibold border border-slate-600">
+          {t("cta.start")}
+        </button>
+        <button className="inline-flex items-center justify-center rounded-lg bg-slate-800/40 hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 text-slate-100 px-6 py-3 text-base font-medium border border-slate-700">
+          {t("cta.later")}
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/apps/web-next/src/app/[locale]/onboarding/page.tsx
+++ b/apps/web-next/src/app/[locale]/onboarding/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { Scene1Promise, Scene2Box, Scene3Key, Scene4Prepare } from "@/components/onboarding/Scenes";
 import { useTranslations } from "next-intl";
 import { track } from "@/lib/analytics";
+import { authAdapter } from "@/lib/auth-adapter";
 
 export default function OnboardingPage({ params }: { params: { locale: string } }) {
   if (!isOnboardingEnabled()) {
@@ -92,8 +93,12 @@ export default function OnboardingPage({ params }: { params: { locale: string } 
       {step === 4 && (
         <Scene4Prepare
           onBack={goBack}
-          onComplete={() => {
+          onComplete={async () => {
             track({ event: "onboarding_complete", locale: params.locale, meta: { boxItemsLen: boxItems.trim().length, hasTrusted: !!trustedName.trim() } });
+            try {
+              const user = await authAdapter.getUser();
+              await authAdapter.setOnboardingCompleted(user.id, new Date());
+            } catch {}
             try {
               if (typeof window !== "undefined") localStorage.removeItem(STORAGE_KEY);
             } catch {}

--- a/apps/web-next/src/app/api/analytics/events/route.ts
+++ b/apps/web-next/src/app/api/analytics/events/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  try {
+    const contentType = req.headers.get("content-type") || "";
+    if (!contentType.includes("application/json")) {
+      return NextResponse.json({ ok: false, error: "invalid_content_type" }, { status: 415 });
+    }
+    const body = await req.json();
+    const event = String(body?.event || "").slice(0, 64);
+    const locale = String(body?.locale || "en").slice(0, 8);
+    const meta = body?.meta && typeof body.meta === "object" ? body.meta : {};
+    if (!event) return NextResponse.json({ ok: false, error: "missing_event" }, { status: 400 });
+
+    console.log("analytics:event", { event, locale, meta, ts: new Date().toISOString(), ua: req.headers.get("user-agent") || undefined });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("analytics:error", err);
+    return NextResponse.json({ ok: false, error: "server_error" }, { status: 500 });
+  }
+}

--- a/apps/web-next/src/components/onboarding/Scenes.tsx
+++ b/apps/web-next/src/components/onboarding/Scenes.tsx
@@ -97,6 +97,7 @@ export function Scene3Key({ initialTrustedName = "", onBack, onNext, onSkip }: {
 
 export function Scene4Prepare({ onBack, onComplete }: { onBack: () => void; onComplete?: () => void }) {
   const t = useTranslations("onboarding.scene4");
+  const reduceMotion = useReducedMotion();
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
       <div className="w-full max-w-2xl text-center border border-primary/20 shadow-xl bg-background/95 backdrop-blur rounded-lg">

--- a/apps/web-next/src/components/onboarding/Scenes.tsx
+++ b/apps/web-next/src/components/onboarding/Scenes.tsx
@@ -3,10 +3,14 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 
 export function Scene1Promise({ onNext, onSkip }: { onNext: () => void; onSkip?: () => void }) {
   const t = useTranslations("onboarding.scene1");
+  const reduceMotion = useReducedMotion();
+  const reveal = reduceMotion
+    ? ({} as any)
+    : ({ initial: { opacity: 0, y: 12 }, animate: { opacity: 1, y: 0 }, transition: { duration: 0.5 } } as any);
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 relative">
       {onSkip && (
@@ -16,11 +20,11 @@ export function Scene1Promise({ onNext, onSkip }: { onNext: () => void; onSkip?:
       )}
       <div className="w-full max-w-2xl text-center border border-primary/20 shadow-xl rounded-lg bg-background/95">
         <div className="pt-10 pb-8 px-6">
-          <h2 className="text-3xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</h2>
-          <p className="text-muted-foreground mb-8 text-lg leading-relaxed">{t("subtitle")}</p>
-          <button className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground font-medium px-8 py-3 text-lg" onClick={onNext}>
+          <motion.h2 {...reveal} className="text-3xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</motion.h2>
+          <motion.p {...reveal} className="text-muted-foreground mb-8 text-lg leading-relaxed">{t("subtitle")}</motion.p>
+          <motion.button whileHover={reduceMotion ? undefined : { scale: 1.02 }} whileTap={reduceMotion ? undefined : { scale: 0.98 }} className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground font-medium px-8 py-3 text-lg" onClick={onNext}>
             {t("cta")}
-          </button>
+          </motion.button>
           <p className="text-xs text-muted-foreground mt-3 opacity-70">{t("foot")}</p>
         </div>
       </div>
@@ -31,6 +35,10 @@ export function Scene1Promise({ onNext, onSkip }: { onNext: () => void; onSkip?:
 export function Scene2Box({ initialItems = "", onBack, onNext, onSkip }: { initialItems?: string; onBack: () => void; onNext: (items: string) => void; onSkip?: () => void }) {
   const t = useTranslations("onboarding.scene2");
   const [items, setItems] = useState(initialItems);
+  const reduceMotion = useReducedMotion();
+  const reveal = reduceMotion
+    ? ({} as any)
+    : ({ initial: { opacity: 0, y: 10 }, animate: { opacity: 1, y: 0 }, transition: { duration: 0.4 } } as any);
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 relative">
       {onSkip && (
@@ -40,15 +48,15 @@ export function Scene2Box({ initialItems = "", onBack, onNext, onSkip }: { initi
       )}
       <div className="w-full max-w-3xl border border-primary/20 shadow-xl rounded-lg bg-background/95">
         <div className="pt-10 pb-8 px-6">
-          <h2 className="text-2xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</h2>
-          <p className="text-muted-foreground mb-6 text-lg leading-relaxed">{t("lead")}</p>
-          <p className="text-sm text-muted-foreground/80 mb-4 italic">{t("hint")}</p>
-          <textarea value={items} onChange={(e) => setItems(e.target.value)} rows={6} className="w-full rounded border border-primary/20 bg-background/50 p-3 mb-6" placeholder={t("ph") as string} />
+          <motion.h2 {...reveal} className="text-2xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</motion.h2>
+          <motion.p {...reveal} className="text-muted-foreground mb-6 text-lg leading-relaxed">{t("lead")}</motion.p>
+          <motion.p {...reveal} className="text-sm text-muted-foreground/80 mb-4 italic">{t("hint")}</motion.p>
+          <motion.textarea {...reveal} value={items} onChange={(e) => setItems(e.target.value)} rows={6} className="w-full rounded border border-primary/20 bg-background/50 p-3 mb-6" placeholder={t("ph") as string} />
           <div className="flex gap-3 justify-between">
             <button onClick={onBack} className="inline-flex items-center justify-center rounded-lg bg-transparent text-foreground px-4 py-2 border border-primary/20 hover:border-primary/40">{t("back")}</button>
             <div className="flex gap-3">
-              <button onClick={() => setItems("")} className="inline-flex items-center justify-center rounded-lg bg-transparent text-foreground px-4 py-2 border border-muted hover:border-muted-foreground/40">{t("clear")}</button>
-              <button onClick={() => onNext(items)} disabled={!items.trim()} className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2 disabled:opacity-60">{t("continue")}</button>
+              <motion.button whileHover={reduceMotion ? undefined : { scale: 1.02 }} onClick={() => setItems("")} className="inline-flex items-center justify-center rounded-lg bg-transparent text-foreground px-4 py-2 border border-muted hover:border-muted-foreground/40">{t("clear")}</motion.button>
+              <motion.button whileHover={reduceMotion ? undefined : { scale: 1.02 }} whileTap={reduceMotion ? undefined : { scale: 0.98 }} onClick={() => onNext(items)} disabled={!items.trim()} className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2 disabled:opacity-60">{t("continue")}</motion.button>
             </div>
           </div>
         </div>
@@ -60,6 +68,10 @@ export function Scene2Box({ initialItems = "", onBack, onNext, onSkip }: { initi
 export function Scene3Key({ initialTrustedName = "", onBack, onNext, onSkip }: { initialTrustedName?: string; onBack: () => void; onNext: (name: string) => void; onSkip?: () => void }) {
   const t = useTranslations("onboarding.scene3");
   const [name, setName] = useState(initialTrustedName);
+  const reduceMotion = useReducedMotion();
+  const reveal = reduceMotion
+    ? ({} as any)
+    : ({ initial: { opacity: 0, y: 10 }, animate: { opacity: 1, y: 0 }, transition: { duration: 0.4 } } as any);
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 relative">
       {onSkip && (
@@ -69,10 +81,10 @@ export function Scene3Key({ initialTrustedName = "", onBack, onNext, onSkip }: {
       )}
       <div className="w-full max-w-3xl border border-primary/20 shadow-xl rounded-lg bg-background/95">
         <div className="pt-10 pb-8 px-6">
-          <h2 className="text-2xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</h2>
-          <p className="text-muted-foreground mb-6 text-lg leading-relaxed">{t("lead")}</p>
-          <p className="text-sm text-muted-foreground/80 mb-6 italic">{t("hint")}</p>
-          <input value={name} onChange={(e) => setName(e.target.value)} placeholder={t("ph") as string} className="w-full h-12 rounded border border-primary/20 bg-background/50 p-3 mb-6" />
+          <motion.h2 {...reveal} className="text-2xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</motion.h2>
+          <motion.p {...reveal} className="text-muted-foreground mb-6 text-lg leading-relaxed">{t("lead")}</motion.p>
+          <motion.p {...reveal} className="text-sm text-muted-foreground/80 mb-6 italic">{t("hint")}</motion.p>
+          <motion.input {...reveal} value={name} onChange={(e) => setName(e.target.value)} placeholder={t("ph") as string} className="w-full h-12 rounded border border-primary/20 bg-background/50 p-3 mb-6" />
           <div className="flex gap-3 justify-between">
             <button onClick={onBack} className="inline-flex items-center justify-center rounded-lg bg-transparent text-foreground px-4 py-2 border border-primary/20 hover:border-primary/40">{t("back")}</button>
             <button onClick={() => onNext(name)} disabled={!name.trim()} className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2 disabled:opacity-60">{t("continue")}</button>
@@ -93,7 +105,7 @@ export function Scene4Prepare({ onBack, onComplete }: { onBack: () => void; onCo
           <p className="text-muted-foreground mb-8 text-lg leading-relaxed">{t("lead")}</p>
           <div className="flex gap-3 justify-center">
             <button onClick={onBack} className="inline-flex items-center justify-center rounded-lg bg-transparent text-foreground px-4 py-2 border border-primary/20 hover:border-primary/40">{t("back")}</button>
-            <button onClick={() => onComplete?.()} className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2">{t("done")}</button>
+            <motion.button whileHover={reduceMotion ? undefined : { scale: 1.02 }} whileTap={reduceMotion ? undefined : { scale: 0.98 }} onClick={() => onComplete?.()} className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2">{t("done")}</motion.button>
           </div>
         </div>
       </div>

--- a/apps/web-next/src/components/onboarding/Scenes.tsx
+++ b/apps/web-next/src/components/onboarding/Scenes.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { motion } from "framer-motion";
+
+export function Scene1Promise({ onNext, onSkip }: { onNext: () => void; onSkip?: () => void }) {
+  const t = useTranslations("onboarding.scene1");
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 relative">
+      {onSkip && (
+        <motion.button onClick={onSkip} className="absolute top-6 right-6 text-sm text-muted-foreground hover:text-foreground transition-colors z-10 bg-background/80 backdrop-blur px-3 py-1 rounded-full border border-border/50 hover:border-border">
+          {t("skip")}
+        </motion.button>
+      )}
+      <div className="w-full max-w-2xl text-center border border-primary/20 shadow-xl rounded-lg bg-background/95">
+        <div className="pt-10 pb-8 px-6">
+          <h2 className="text-3xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</h2>
+          <p className="text-muted-foreground mb-8 text-lg leading-relaxed">{t("subtitle")}</p>
+          <button className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground font-medium px-8 py-3 text-lg" onClick={onNext}>
+            {t("cta")}
+          </button>
+          <p className="text-xs text-muted-foreground mt-3 opacity-70">{t("foot")}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function Scene2Box({ initialItems = "", onBack, onNext, onSkip }: { initialItems?: string; onBack: () => void; onNext: (items: string) => void; onSkip?: () => void }) {
+  const t = useTranslations("onboarding.scene2");
+  const [items, setItems] = useState(initialItems);
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 relative">
+      {onSkip && (
+        <motion.button onClick={onSkip} className="absolute top-6 right-6 text-sm text-muted-foreground hover:text-foreground transition-colors z-10 bg-background/80 backdrop-blur px-3 py-1 rounded-full border border-border/50 hover:border-border">
+          {t("skip")}
+        </motion.button>
+      )}
+      <div className="w-full max-w-3xl border border-primary/20 shadow-xl rounded-lg bg-background/95">
+        <div className="pt-10 pb-8 px-6">
+          <h2 className="text-2xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</h2>
+          <p className="text-muted-foreground mb-6 text-lg leading-relaxed">{t("lead")}</p>
+          <p className="text-sm text-muted-foreground/80 mb-4 italic">{t("hint")}</p>
+          <textarea value={items} onChange={(e) => setItems(e.target.value)} rows={6} className="w-full rounded border border-primary/20 bg-background/50 p-3 mb-6" placeholder={t("ph") as string} />
+          <div className="flex gap-3 justify-between">
+            <button onClick={onBack} className="inline-flex items-center justify-center rounded-lg bg-transparent text-foreground px-4 py-2 border border-primary/20 hover:border-primary/40">{t("back")}</button>
+            <div className="flex gap-3">
+              <button onClick={() => setItems("")} className="inline-flex items-center justify-center rounded-lg bg-transparent text-foreground px-4 py-2 border border-muted hover:border-muted-foreground/40">{t("clear")}</button>
+              <button onClick={() => onNext(items)} disabled={!items.trim()} className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2 disabled:opacity-60">{t("continue")}</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function Scene3Key({ initialTrustedName = "", onBack, onNext, onSkip }: { initialTrustedName?: string; onBack: () => void; onNext: (name: string) => void; onSkip?: () => void }) {
+  const t = useTranslations("onboarding.scene3");
+  const [name, setName] = useState(initialTrustedName);
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 relative">
+      {onSkip && (
+        <motion.button onClick={onSkip} className="absolute top-6 right-6 text-sm text-muted-foreground hover:text-foreground transition-colors z-10 bg-background/80 backdrop-blur px-3 py-1 rounded-full border border-border/50 hover:border-border">
+          {t("skip")}
+        </motion.button>
+      )}
+      <div className="w-full max-w-3xl border border-primary/20 shadow-xl rounded-lg bg-background/95">
+        <div className="pt-10 pb-8 px-6">
+          <h2 className="text-2xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</h2>
+          <p className="text-muted-foreground mb-6 text-lg leading-relaxed">{t("lead")}</p>
+          <p className="text-sm text-muted-foreground/80 mb-6 italic">{t("hint")}</p>
+          <input value={name} onChange={(e) => setName(e.target.value)} placeholder={t("ph") as string} className="w-full h-12 rounded border border-primary/20 bg-background/50 p-3 mb-6" />
+          <div className="flex gap-3 justify-between">
+            <button onClick={onBack} className="inline-flex items-center justify-center rounded-lg bg-transparent text-foreground px-4 py-2 border border-primary/20 hover:border-primary/40">{t("back")}</button>
+            <button onClick={() => onNext(name)} disabled={!name.trim()} className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2 disabled:opacity-60">{t("continue")}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function Scene4Prepare({ onBack, onComplete }: { onBack: () => void; onComplete?: () => void }) {
+  const t = useTranslations("onboarding.scene4");
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+      <div className="w-full max-w-2xl text-center border border-primary/20 shadow-xl bg-background/95 backdrop-blur rounded-lg">
+        <div className="pt-10 pb-8 px-6">
+          <h2 className="text-2xl font-heading bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">{t("title")}</h2>
+          <p className="text-muted-foreground mb-8 text-lg leading-relaxed">{t("lead")}</p>
+          <div className="flex gap-3 justify-center">
+            <button onClick={onBack} className="inline-flex items-center justify-center rounded-lg bg-transparent text-foreground px-4 py-2 border border-primary/20 hover:border-primary/40">{t("back")}</button>
+            <button onClick={() => onComplete?.()} className="inline-flex items-center justify-center rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2">{t("done")}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-next/src/config/flags.ts
+++ b/apps/web-next/src/config/flags.ts
@@ -1,0 +1,22 @@
+// Feature flag parsing utilities for Next.js app (apps/web-next)
+// All code in English; user-facing copy belongs in i18n JSONs.
+
+function parseBoolean(value: string | undefined, defaultValue = false): boolean {
+  if (value === undefined || value === null) return defaultValue;
+  const v = value.trim();
+  if (v === "") return defaultValue;
+  return /^(1|true|yes|on)$/i.test(v);
+}
+
+export function isHollywoodLandingEnabled(): boolean {
+  return parseBoolean(process.env.NEXT_PUBLIC_ENABLE_HOLLYWOOD_LANDING, false);
+}
+
+export function isOnboardingEnabled(): boolean {
+  return parseBoolean(process.env.NEXT_PUBLIC_ENABLE_ONBOARDING, false);
+}
+
+export const flags = {
+  hollywoodLandingEnabled: isHollywoodLandingEnabled,
+  onboardingEnabled: isOnboardingEnabled,
+};

--- a/apps/web-next/src/i18n/request.ts
+++ b/apps/web-next/src/i18n/request.ts
@@ -14,8 +14,20 @@ export default getRequestConfig(async () => {
   // Validate that the incoming `locale` parameter is valid
   if (!locales.includes(locale as Locale)) notFound();
 
+  // Load base messages and optional onboarding namespace
+  const base = (await import(`../../messages/${locale}.json`).catch(() => ({ default: {} as any }))).default as any;
+  const onboarding = (await import(`../messages/${locale}/onboarding.json`).catch(() => ({ default: {} as any }))).default as any;
+
+  const messages = {
+    ...base,
+    onboarding: {
+      ...(base?.onboarding || {}),
+      ...onboarding,
+    },
+  } as any;
+
   return {
     locale,
-    messages: (await import(`../../messages/${locale}.json`)).default,
+    messages,
   };
 });

--- a/apps/web-next/src/lib/analytics.ts
+++ b/apps/web-next/src/lib/analytics.ts
@@ -1,0 +1,32 @@
+// Small client helper to send analytics events safely
+// No secrets, no PII. Uses navigator.sendBeacon when available.
+
+export type AnalyticsEvent = {
+  event: string;
+  locale: string;
+  meta?: Record<string, unknown>;
+};
+
+const ENDPOINT = "/api/analytics/events";
+
+export function track(event: AnalyticsEvent) {
+  try {
+    const payload = JSON.stringify(event);
+    if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
+      const blob = new Blob([payload], { type: "application/json" });
+      navigator.sendBeacon(ENDPOINT, blob);
+      return;
+    }
+
+    // Fallback to fetch
+    void fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      keepalive: true,
+    });
+  } catch (err) {
+    // Swallow errors in analytics path
+    console.warn("analytics:track_error", err);
+  }
+}

--- a/apps/web-next/src/lib/auth-adapter.ts
+++ b/apps/web-next/src/lib/auth-adapter.ts
@@ -1,0 +1,25 @@
+// Minimal Auth Adapter (no-op) for onboarding integration
+// Safe default: does not call external providers; stores a small marker in localStorage.
+
+export type User = { id: string | null };
+
+export interface AuthAdapter {
+  getUser(): Promise<User>;
+  setOnboardingCompleted(userId: string | null, at: Date): Promise<void>;
+}
+
+export const authAdapter: AuthAdapter = {
+  async getUser(): Promise<User> {
+    // No-op user (not signed in). Later, replace with real provider implementation.
+    return { id: null };
+  },
+  async setOnboardingCompleted(userId: string | null, at: Date): Promise<void> {
+    try {
+      if (typeof window === 'undefined') return;
+      const payload = { userId, at: at.toISOString() };
+      localStorage.setItem('onb_completed_marker', JSON.stringify(payload));
+    } catch {
+      // ignore storage errors
+    }
+  },
+};

--- a/apps/web-next/src/messages/cs/onboarding.json
+++ b/apps/web-next/src/messages/cs/onboarding.json
@@ -5,5 +5,9 @@
     "heading": "Váš startovací plán",
     "description": "Tyto milníky vám pomohou začít s jistotou."
   },
-  "cta": { "start": "Začít nyní", "later": "Možná později" }
+  "cta": { "start": "Začít nyní", "later": "Možná později" },
+  "scene1": { "skip": "Přeskočit úvod", "title": "Vítejte v klidném začátku", "subtitle": "Jemná cesta k ochraně toho, na čem záleží.", "cta": "Začít", "foot": "Vše můžete později upravit." },
+  "scene2": { "skip": "Přeskočit úvod", "title": "Truhla jistoty", "lead": "Představte si jedinou truhlu... Co byste do ní vložili?", "hint": "Je to o lásce, ne o logistice.", "ph": "Klíče od domu, dopis pro dceru, ...", "back": "← Zpět", "clear": "Vyčistit", "continue": "Pokračovat →" },
+  "scene3": { "skip": "Přeskočit úvod", "title": "Klíč důvěry", "lead": "Komu byste svěřili klíč k této truhle?", "hint": "Zvolte někoho, kdo zná vaše srdce.", "ph": "např. Martina, Jan, Máma...", "back": "← Zpět", "continue": "Pokračovat →" },
+  "scene4": { "title": "Připravuji vaši cestu", "lead": "Děkuji. Připravuji Cestu klidu.", "back": "← Zpět", "done": "Dokončit" }
 }

--- a/apps/web-next/src/messages/cs/onboarding.json
+++ b/apps/web-next/src/messages/cs/onboarding.json
@@ -1,0 +1,9 @@
+{
+  "title": "Poznejme se v pár jemných krocích",
+  "subtitle": "Z vašich odpovědí vytvoříme jednoduchý, klidný plán — vaším tempem.",
+  "plan": {
+    "heading": "Váš startovací plán",
+    "description": "Tyto milníky vám pomohou začít s jistotou."
+  },
+  "cta": { "start": "Začít nyní", "later": "Možná později" }
+}

--- a/apps/web-next/src/messages/en/onboarding.json
+++ b/apps/web-next/src/messages/en/onboarding.json
@@ -1,0 +1,9 @@
+{
+  "title": "Let’s get to know you in a few gentle steps",
+  "subtitle": "We’ll turn your answers into a simple, calm plan—at your pace.",
+  "plan": {
+    "heading": "Your starting plan",
+    "description": "These milestones are tailored to help you begin with confidence."
+  },
+  "cta": { "start": "Start now", "later": "Maybe later" }
+}

--- a/apps/web-next/src/messages/en/onboarding.json
+++ b/apps/web-next/src/messages/en/onboarding.json
@@ -5,5 +5,9 @@
     "heading": "Your starting plan",
     "description": "These milestones are tailored to help you begin with confidence."
   },
-  "cta": { "start": "Start now", "later": "Maybe later" }
+  "cta": { "start": "Start now", "later": "Maybe later" },
+  "scene1": { "skip": "Skip introduction", "title": "Welcome to your calm beginning", "subtitle": "A gentle path to protect what matters.", "cta": "Begin", "foot": "You can adjust everything later." },
+  "scene2": { "skip": "Skip introduction", "title": "The Box of Certainty", "lead": "Imagine leaving a single box... What would you put inside?", "hint": "This is about love, not logistics.", "ph": "House keys, letter for my daughter, ...", "back": "← Back", "clear": "Clear", "continue": "Continue →" },
+  "scene3": { "skip": "Skip introduction", "title": "The Key of Trust", "lead": "Who is the one person...", "hint": "Choose someone who knows your heart.", "ph": "e.g., Martina, John, Mom...", "back": "← Back", "continue": "Continue →" },
+  "scene4": { "title": "Preparing Your Path", "lead": "Thank you. I’m preparing your Path of Peace.", "back": "← Back", "done": "Finish" }
 }

--- a/apps/web-next/src/messages/sk/onboarding.json
+++ b/apps/web-next/src/messages/sk/onboarding.json
@@ -1,0 +1,9 @@
+{
+  "title": "Spoznajme sa v pár jemných krokoch",
+  "subtitle": "Z vašich odpovedí vytvoríme jednoduchý, pokojný plán — vaším tempom.",
+  "plan": {
+    "heading": "Váš štartovací plán",
+    "description": "Tieto míľniky vám pomôžu začať s istotou."
+  },
+  "cta": { "start": "Začať teraz", "later": "Možno neskôr" }
+}

--- a/apps/web-next/src/messages/sk/onboarding.json
+++ b/apps/web-next/src/messages/sk/onboarding.json
@@ -5,5 +5,9 @@
     "heading": "Váš štartovací plán",
     "description": "Tieto míľniky vám pomôžu začať s istotou."
   },
-  "cta": { "start": "Začať teraz", "later": "Možno neskôr" }
+  "cta": { "start": "Začať teraz", "later": "Možno neskôr" },
+  "scene1": { "skip": "Preskočiť úvod", "title": "Vitajte v pokojnom začiatku", "subtitle": "Jemná cesta k ochrane toho, na čom záleží.", "cta": "Začať", "foot": "Všetko môžete neskôr upraviť." },
+  "scene2": { "skip": "Preskočiť úvod", "title": "Truhlica istoty", "lead": "Predstavte si jedinú truhlicu... Čo by ste do nej vložili?", "hint": "Je to o láske, nie o logistike.", "ph": "Kľúče od domu, list pre dcéru, ...", "back": "← Späť", "clear": "Vyčistiť", "continue": "Pokračovať →" },
+  "scene3": { "skip": "Preskočiť úvod", "title": "Kľúč dôvery", "lead": "Komu by ste zverili kľúč k tejto truhlici?", "hint": "Vyberte niekoho, kto pozná vaše srdce.", "ph": "napr. Martina, Ján, Mama...", "back": "← Späť", "continue": "Pokračovať →" },
+  "scene4": { "title": "Pripravujem vašu cestu", "lead": "Ďakujem. Pripravujem Cestu pokoja.", "back": "← Späť", "done": "Dokončiť" }
 }

--- a/apps/web-next/tests/onboarding-flow.spec.ts
+++ b/apps/web-next/tests/onboarding-flow.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test'
+
+// End-to-end smoke for onboarding flow: steps 1 -> 4
+// Note: Requires NEXT_PUBLIC_ENABLE_ONBOARDING=true when running dev server.
+
+test('onboarding flow: step through 1 -> 4 (en)', async ({ page }) => {
+  await page.goto('/en/onboarding');
+
+  // If feature flag is off, skip gracefully
+  if ((await page.title()).includes('404') || page.url().includes('/404')) {
+    test.skip(true, 'Onboarding flag disabled; skipping full flow test');
+  }
+
+  // Scene 1: Begin
+  const begin = page.getByRole('button', { name: /begin/i });
+  await expect(begin).toBeVisible();
+  await begin.click();
+
+  // Scene 2: Fill textarea and Continue
+  const textarea = page.locator('textarea').first();
+  await expect(textarea).toBeVisible();
+  await textarea.fill("house keys, letter for my daughter, recipe");
+  const cont1 = page.getByRole('button', { name: /continue/i });
+  await expect(cont1).toBeVisible();
+  await cont1.click();
+
+  // Scene 3: Fill input and Continue
+  const input = page.locator('input').first();
+  await expect(input).toBeVisible();
+  await input.fill('John');
+  const cont2 = page.getByRole('button', { name: /continue/i });
+  await expect(cont2).toBeVisible();
+  await cont2.click();
+
+  // Scene 4: Finish
+  const finish = page.getByRole('button', { name: /finish/i });
+  await expect(finish).toBeVisible();
+  await finish.click();
+
+  // Best-effort: give time for completion side-effects (analytics, storage cleanup)
+  await page.waitForTimeout(200);
+});

--- a/apps/web-next/tests/onboarding.spec.ts
+++ b/apps/web-next/tests/onboarding.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test'
+
+// Smoke test for onboarding route (feature-flagged)
+
+test('onboarding route guarded and renders when enabled', async ({ page }) => {
+  await page.goto('/en/onboarding');
+
+  if ((await page.title()).includes('404') || page.url().includes('/404')) {
+    test.skip(true, 'Onboarding flag disabled; skipping test');
+  }
+
+  await expect(page.locator('h1')).toBeVisible();
+  await expect(page.getByRole('button', { name: /start/i })).toBeVisible();
+});

--- a/apps/web-next/tsconfig.onboarding-check.json
+++ b/apps/web-next/tsconfig.onboarding-check.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/app/[locale]/onboarding/page.tsx",
+    "src/config/flags.ts",
+    "src/messages/en/onboarding.json",
+    "src/messages/sk/onboarding.json",
+    "src/messages/cs/onboarding.json"
+  ],
+  "exclude": []
+}

--- a/apps/web-next/tsconfig.onboarding-check.json
+++ b/apps/web-next/tsconfig.onboarding-check.json
@@ -4,6 +4,7 @@
     "src/app/[locale]/onboarding/page.tsx",
     "src/components/onboarding/Scenes.tsx",
     "src/lib/analytics.ts",
+    "src/lib/auth-adapter.ts",
     "src/config/flags.ts",
     "src/messages/en/onboarding.json",
     "src/messages/sk/onboarding.json",

--- a/apps/web-next/tsconfig.onboarding-check.json
+++ b/apps/web-next/tsconfig.onboarding-check.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/app/[locale]/onboarding/page.tsx",
+    "src/components/onboarding/Scenes.tsx",
     "src/config/flags.ts",
     "src/messages/en/onboarding.json",
     "src/messages/sk/onboarding.json",

--- a/apps/web-next/tsconfig.onboarding-check.json
+++ b/apps/web-next/tsconfig.onboarding-check.json
@@ -3,6 +3,7 @@
   "include": [
     "src/app/[locale]/onboarding/page.tsx",
     "src/components/onboarding/Scenes.tsx",
+    "src/lib/analytics.ts",
     "src/config/flags.ts",
     "src/messages/en/onboarding.json",
     "src/messages/sk/onboarding.json",

--- a/docs/migration/hollywood-to-schwalbe-mapping.md
+++ b/docs/migration/hollywood-to-schwalbe-mapping.md
@@ -1,35 +1,40 @@
 # Hollywood → Schwalbe Migration Mapping
 
 Intent
+
 - Extract core concepts and architecture rather than copy-paste; adapt to Schwalbe naming and rules while preserving functionality and purpose.
 
 Applications
+
 - Hollywood Web → Schwalbe apps/web
 - Hollywood Mobile → Schwalbe apps/mobile
 - Hollywood Demo → Schwalbe apps/demo
 Evidence: /Users/luborfedak/Documents/Github/hollywood/docs/README.md:11-23; DEVELOPER_GUIDE_EN.md:274-323
 
 Packages
+
 - Hollywood packages/ui → Schwalbe packages/ui
 - Hollywood packages/logic → Schwalbe packages/logic
 - Hollywood packages/shared → Schwalbe packages/shared
 Evidence: /Users/luborfedak/Documents/Github/hollywood/docs/DEVELOPER_GUIDE_EN.md:29-35,132-147
 
 Backend
+
 - Supabase (DB/Auth/Realtime/Storage) + Edge Functions retained.
 Evidence: /Users/luborfedak/Documents/Github/hollywood/docs/DEVELOPER_GUIDE_EN.md:37-41
 
 Key Adaptations and Cautions
+
 - Error tracking: replace Sentry with Supabase logs + DB + Resend.
 - React version: validate React 19.1.1 compatibility; fallback to 18.3.1 if needed.
 - Environment variables: synchronize with Schwalbe env doc (Sentry removed; add logging settings if needed).
 - i18n language set: apply Schwalbe rules (language replacements/additions) and ensure minimum language count per country.
 
 Phase B (Onboarding) – status
+
 - Feature flag: NEXT_PUBLIC_ENABLE_ONBOARDING (default OFF)
 - Package: packages/onboarding (types + minimal plan generator)
 - Route: apps/web-next/src/app/[locale]/onboarding/page.tsx (flag-guarded)
 - i18n: apps/web-next/src/messages/{en,sk,cs}/onboarding.json
 - Targeted typecheck: apps/web-next/tsconfig.onboarding-check.json
 - E2E: apps/web-next/tests/onboarding.spec.ts
-

--- a/docs/migration/hollywood-to-schwalbe-mapping.md
+++ b/docs/migration/hollywood-to-schwalbe-mapping.md
@@ -25,3 +25,11 @@ Key Adaptations and Cautions
 - Environment variables: synchronize with Schwalbe env doc (Sentry removed; add logging settings if needed).
 - i18n language set: apply Schwalbe rules (language replacements/additions) and ensure minimum language count per country.
 
+Phase B (Onboarding) – status
+- Feature flag: NEXT_PUBLIC_ENABLE_ONBOARDING (default OFF)
+- Package: packages/onboarding (types + minimal plan generator)
+- Route: apps/web-next/src/app/[locale]/onboarding/page.tsx (flag-guarded)
+- i18n: apps/web-next/src/messages/{en,sk,cs}/onboarding.json
+- Targeted typecheck: apps/web-next/tsconfig.onboarding-check.json
+- E2E: apps/web-next/tests/onboarding.spec.ts
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "workspaces": [
         "apps/web-next",
         "apps/mobile",
-        "packages/*"
+        "packages/*",
+        "packages/onboarding"
       ],
       "dependencies": {
         "resend": "^6.1.0"
@@ -6923,6 +6924,10 @@
     },
     "node_modules/@schwalbe/mobile": {
       "resolved": "apps/mobile",
+      "link": true
+    },
+    "node_modules/@schwalbe/onboarding": {
+      "resolved": "packages/onboarding",
       "link": true
     },
     "node_modules/@schwalbe/shared": {
@@ -26164,6 +26169,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "packages/onboarding": {
+      "name": "@schwalbe/onboarding",
+      "version": "0.1.0"
     },
     "packages/shared": {
       "name": "@schwalbe/shared",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "workspaces": [
     "apps/web-next",
     "apps/mobile",
-    "packages/*"
+    "packages/*",
+    "packages/onboarding"
   ],
   "scripts": {
     "dev": "NODE_OPTIONS=--max-old-space-size=8192 turbo run dev",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@schwalbe/onboarding",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -1,0 +1,58 @@
+// Onboarding package skeleton: domain types and a minimal plan generator.
+// Code in English; UI copy in next-intl JSONs.
+
+export type Persona =
+  | 'starter'
+  | 'planner'
+  | 'guardian';
+
+export type Answer = {
+  key: 'familyStatus' | 'priority' | 'timeAvailable';
+  value: string;
+};
+
+export type Milestone = {
+  id: string;
+  title: string;
+  description: string;
+  estimateMinutes: number;
+};
+
+export type Plan = {
+  persona: Persona;
+  milestones: Milestone[];
+  nextBestAction: Milestone | null;
+};
+
+export function inferPersona(answers: Answer[]): Persona {
+  const priority = answers.find(a => a.key === 'priority')?.value || 'safety';
+  if (priority === 'organization') return 'planner';
+  if (priority === 'family') return 'guardian';
+  return 'starter';
+}
+
+export function generatePlan(answers: Answer[]): Plan {
+  const persona = inferPersona(answers);
+  const milestones: Milestone[] = [];
+
+  // Minimal rules based on persona
+  if (persona === 'starter') {
+    milestones.push(
+      { id: 'vault-basics', title: 'Secure your first documents', description: 'Add ID, insurance, and a key contact.', estimateMinutes: 8 },
+      { id: 'guardian-add', title: 'Add a trusted guardian', description: 'Invite someone you trust as a guardian.', estimateMinutes: 6 },
+    );
+  } else if (persona === 'planner') {
+    milestones.push(
+      { id: 'organize-categories', title: 'Organize your categories', description: 'Create categories for documents and assets.', estimateMinutes: 10 },
+      { id: 'checklist', title: 'Build your gentle checklist', description: 'Set reminders and next steps.', estimateMinutes: 7 },
+    );
+  } else {
+    milestones.push(
+      { id: 'family-contacts', title: 'Set up family contacts', description: 'Add spouse and children contacts.', estimateMinutes: 7 },
+      { id: 'emergency-access', title: 'Prepare emergency access', description: 'Define how your family can access in emergencies.', estimateMinutes: 9 },
+    );
+  }
+
+  const nextBestAction = milestones[0] ?? null;
+  return { persona, milestones, nextBestAction };
+}

--- a/packages/onboarding/tsconfig.json
+++ b/packages/onboarding/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./packages/shared" },
     { "path": "./packages/logic" },
+    { "path": "./packages/onboarding" },
     { "path": "./apps/web" }
   ],
   "compilerOptions": {


### PR DESCRIPTION
Phase B is ready for review.\n\nScope in this PR:\n- Feature flag: NEXT_PUBLIC_ENABLE_ONBOARDING (default OFF).\n- Package: @schwalbe/onboarding (types + minimal plan generator).\n- Route: /[locale]/onboarding (App Router).\n- Copy: next-intl namespaces for onboarding (en/sk/cs).\n- Analytics: onboarding_view, onboarding_step_next/back, onboarding_complete.\n- Persistence: localStorage of step, boxItems, trustedName (+ cleanup).\n- Gentle animations with reduced-motion support.\n- No-op Auth adapter wired on completion (safe marker only).\n- e2e: Playwright smoke for flow (1→4).\n\nAll changes are isolated, incremental, and behind feature flags.